### PR TITLE
fix: incorrect install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Returns an `xml.etree.ElementTree.Element` root node.
 ## Installation
 
 ```bash
-uv add sloppy-xml-py
+uv add sloppy-xml
 ```
 
 ## Development


### PR DESCRIPTION
This PR fixes the install command in the README. `uv add sloppy-xml-py` doesn't work, it should be `uv add sloppy-xml`.